### PR TITLE
Try discerning public law courts from private

### DIFF
--- a/src/juris-at-desc.json
+++ b/src/juris-at-desc.json
@@ -32,13 +32,9 @@
       "name": "Handelsgericht",
       "abbrev": "HG >"
     },
-    "vgwg": {
-      "name": "Verwaltungsgericht",
-      "abbrev": "VGWG >"
-    },
     "bfg": {
       "name": "Bundesfinanzgericht",
-      "abbrev": "Verwaltungsgericht"
+      "abbrev": "BFG"
     },
     "bvwg": {
       "name": "Bundesverwaltungsgericht",
@@ -62,20 +58,94 @@
       "path": "at",
       "name": "Austria",
       "courts": [
-        "bfg",
-        "bvwg",
-        "ogh",
+        "ogh"
+      ]
+    },
+    {
+      "path": "at/a",
+      "courts": [
         "vfgh",
         "vwgh"
       ]
     },
     {
-      "path": "at/burgenland",
+      "path": "at/a/at",
+      "courts": [
+        "bfg",
+        "bvwg"
+      ]
+    },
+    {
+      "path": "at/a/burgenland",
       "name": "Burgenland",
       "courts": [
         "lvwg"
       ],
-      "abbrev": "Burgenland"
+      "abbrev": "Bgld"
+    },
+    {
+      "path": "at/a/karnten",
+      "name": "Kärnten",
+      "courts": [
+        "lvwg"
+      ],
+      "abbrev": "Ktn"
+    },
+    {
+      "path": "at/a/niederosterreich",
+      "name": "Niederösterreich",
+      "courts": [
+        "lvwg"
+      ],
+      "abbrev": "NÖ"
+    },
+    {
+      "path": "at/a/oberosterreich",
+      "name": "Oberösterreich",
+      "courts": [
+        "lvwg"
+      ],
+      "abbrev": "OÖ"
+    },
+    {
+      "path": "at/a/salzburg",
+      "name": "Salzburg",
+      "courts": [
+        "lvwg"
+      ],
+      "abbrev": "Sbg"
+    },
+    {
+      "path": "at/a/steiermark",
+      "name": "Steiermark",
+      "courts": [
+        "lvwg"
+      ],
+      "abbrev": "Stmk"
+    },
+    {
+      "path": "at/a/tirol",
+      "name": "Tirol",
+      "courts": [
+        "lvwg"
+      ],
+      "abbrev": "Tir"
+    },
+    {
+      "path": "at/a/vorarlberg",
+      "name": "Vorarlberg",
+      "courts": [
+        "lvwg"
+      ],
+      "abbrev": "Vlbg"
+    },
+    {
+      "path": "at/a/wien",
+      "name": "Wien",
+      "courts": [
+        "lvwg"
+      ],
+      "abbrev": "Wien"
     },
     {
       "path": "at/graz",
@@ -487,14 +557,6 @@
       "abbrev": "Zell am Ziller"
     },
     {
-      "path": "at/karnten",
-      "name": "Kärnten",
-      "courts": [
-        "lvwg"
-      ],
-      "abbrev": "Kärnten"
-    },
-    {
       "path": "at/linz",
       "name": "Linz",
       "courts": [
@@ -751,59 +813,10 @@
       "abbrev": "Wels"
     },
     {
-      "path": "at/niederosterreich",
-      "name": "Niederösterreich",
-      "courts": [
-        "lvwg"
-      ],
-      "abbrev": "Niederösterreich"
-    },
-    {
-      "path": "at/oberosterreich",
-      "name": "Oberösterreich",
-      "courts": [
-        "lvwg"
-      ],
-      "abbrev": "Oberösterreich"
-    },
-    {
-      "path": "at/salzburg",
-      "name": "Salzburg",
-      "courts": [
-        "lvwg"
-      ],
-      "abbrev": "Salzburg"
-    },
-    {
-      "path": "at/steiermark",
-      "name": "Steiermark",
-      "courts": [
-        "lvwg"
-      ],
-      "abbrev": "Steiermark"
-    },
-    {
-      "path": "at/tirol",
-      "name": "Tirol",
-      "courts": [
-        "lvwg"
-      ],
-      "abbrev": "Tirol"
-    },
-    {
-      "path": "at/vorarlberg",
-      "name": "Vorarlberg",
-      "courts": [
-        "lvwg"
-      ],
-      "abbrev": "Vorarlberg"
-    },
-    {
       "path": "at/wien",
       "name": "Wien",
       "courts": [
-        "olg",
-        "vgwg"
+        "olg"
       ],
       "abbrev": "Wien"
     },

--- a/src/juris-eu.int-desc.json
+++ b/src/juris-eu.int-desc.json
@@ -1,10 +1,13 @@
 {
   "courts": {
     "ag": {
-      "name": "Attorney General"
+      "name": "Attorney General",
+      "abbrev:de": "GA"
     },
     "ecj": {
-      "name": "Cour de Justice"
+      "name": "Cour de Justice",
+      "abbrev": "ECJ",
+      "abbrev:de": "EuGH"
     },
     "ecj~chamber.1": {
       "name": "Cour de Justice|First Chamber"
@@ -34,7 +37,17 @@
       "name": "Cour de Justice|Ninth Chamber"
     },
     "ec": {
-      "name": "European Commission"
+      "name": "European Commission",
+      "abbrev:de": "Kom"
+    },
+    "egc": {
+      "name": "General Court",
+      "abbrev": "EGC",
+      "abbrev:de": "EuG"
+    },
+    "cst": {
+      "name": "European Union Civil Service Tribunal",
+      "abbrev:de": "EuGöD"
     }
   },
   "jurisdictions": [
@@ -59,7 +72,9 @@
         "ecj~chamber.6",
         "ecj~chamber.7",
         "ecj~chamber.8",
-        "ecj~chamber.9"
+        "ecj~chamber.9",
+        "egc",
+        "cst"
       ]
     },
     {

--- a/src/juris-eu.int-desc.json
+++ b/src/juris-eu.int-desc.json
@@ -1,13 +1,10 @@
 {
   "courts": {
     "ag": {
-      "name": "Attorney General",
-      "abbrev:de": "GA"
+      "name": "Attorney General"
     },
     "ecj": {
-      "name": "Cour de Justice",
-      "abbrev": "ECJ",
-      "abbrev:de": "EuGH"
+      "name": "Cour de Justice"
     },
     "ecj~chamber.1": {
       "name": "Cour de Justice|First Chamber"
@@ -37,17 +34,7 @@
       "name": "Cour de Justice|Ninth Chamber"
     },
     "ec": {
-      "name": "European Commission",
-      "abbrev:de": "Kom"
-    },
-    "egc": {
-      "name": "General Court",
-      "abbrev": "EGC",
-      "abbrev:de": "EuG"
-    },
-    "cst": {
-      "name": "European Union Civil Service Tribunal",
-      "abbrev:de": "EuGöD"
+      "name": "European Commission"
     }
   },
   "jurisdictions": [
@@ -72,9 +59,7 @@
         "ecj~chamber.6",
         "ecj~chamber.7",
         "ecj~chamber.8",
-        "ecj~chamber.9",
-        "egc",
-        "cst"
+        "ecj~chamber.9"
       ]
     },
     {


### PR DESCRIPTION
Following our discussion by mail about separating the two branches of public law courts versus private and criminal law courts.  
- My idea was to introduce flag "a" for public law courts which comprise all the administratvie courts plus the constitutional court.  
- I introduced a lower level "at" for federal administrative courts (currently bfg and bvwg), which are on the same level in the appeal stages as the regional administrative courts (8 lvwg and vgw).  
- As all this originated in the question of sorting, we should take care that vfgh be sorted before vwgh which in lexical sorting luckily shouldn’t pose any problem.
- If it’s made possible to configure at/a/ to sort before any other at/ it won’t be necessary to flag the private and criminal law branch courts.
- The at/a level courts and the at/a/at shouldn’t print a jurisdiction name – I fear it will cause problems to leave them away?