### PR TITLE
Reworked Canada

### DIFF
--- a/src/juris-ca-desc.json
+++ b/src/juris-ca-desc.json
@@ -104,165 +104,172 @@
       "name": "Superior Court",
       "abbrev": "<CS",
       "ABBREV": "<CS"
+    },
+    "quebec.admin.tribunal": {
+      "name": "Tribunal administratif du Québec",
+      "abbrev": "<TAQ",
+      "ABBREV": "<TAQ"
     }
   },
   "jurisdictions": [
     {
       "path": "ca",
       "name": "Canada",
-      "abbrev": "C",
       "courts": [
         "supreme.court",
         "federal.court",
         "federal.court.appeal",
         "tax.court",
         "court.martial.appeal.court"
-      ]
+      ],
+      "abbrev": "C",
+      "ABBREV": "C"
     },
     {
       "path": "ca/ab",
       "name": "Alberta",
-      "abbrev": "Alta",
-      "ABBREV": "AB",
       "courts" : [
         "court.appeal",
         "court.queens.bench",
         "provincial.court"
-      ]
+      ],
+      "abbrev": "Alta",
+      "ABBREV": "AB"
     },
     {
       "path": "ca/bc",
       "name": "British Columbia",
-      "abbrev": "BC",
-      "ABBREV": "BC",
       "courts": [
         "court.appeal",
         "supreme.court.prov",
         "provincial.court"
-      ]
+      ],
+      "abbrev": "BC",
+      "ABBREV": "BC"
     },
     {
       "path": "ca/mb",
       "name": "Manitoba",
-      "abbrev": "Man",
-      "ABBREV": "MB",
       "courts" : [
         "court.appeal",
         "court.queens.bench",
         "provincial.court"
-      ]
+      ],
+      "abbrev": "Man",
+      "ABBREV": "MB"
     },
     {
       "path": "ca/nb",
       "name": "New-Brunswick",
-      "abbrev": "NB",
-      "abbrev:fr": "N-B",
-      "ABBREV": "NB",
       "courts" : [
         "court.appeal",
         "court.queens.bench",
         "provincial.court"        
-      ]
+      ],
+      "abbrev": "NB",
+      "abbrev:fr": "N-B",
+      "ABBREV": "NB"
     },
     {
       "path": "ca/nl",
       "name": "Newfoundland & Labrador",
-      "abbrev": "NL",
-      "ABBREV": "NL",
       "courts" : [
         "supreme.court.court.appeal",
         "supreme.court.trial.division.nl"        
-      ]
+      ],
+      "abbrev": "NL",
+      "ABBREV": "NL"
     },
     {
       "path": "ca/ns",
       "name": "Nova Scotia",
-      "abbrev": "NS",
-      "ABBREV": "NS",
       "courts" : [
         "court.appeal",
         "supreme.court.prov",
         "family.court",
         "provincial.court"
-      ]
+      ],
+      "abbrev": "NS",
+      "ABBREV": "NS"
     },
     {
       "path": "ca/nt",
       "name": "Northwest Territories",
-      "abbrev": "NWT",
-      "abbrev:fr": "TN-O",
-      "ABBREV": "NWT",
       "courts" : [
         "court.appeal",
         "supreme.court.prov",
         "territorial.court"
-      ]
+      ],
+      "abbrev": "NWT",
+      "abbrev:fr": "TN-O",
+      "ABBREV": "NWT"
     },
     {
       "path": "ca/nu",
       "name": "Nunavut",
-      "abbrev": "Nu",
-      "ABBREV": "NU",
       "courts" : [
         "court.justice",
         "court.appeal"
-      ]
+      ],
+      "abbrev": "NU",
+      "ABBREV": "NU"
     },
     {
       "path": "ca/on",
       "name": "Ontario",
-      "abbrev": "Ont",
-      "ABBREV": "ON",
       "courts" : [
         "court.appeal",
         "superior.court.justice",
         "court.justice"
-      ]
+      ],
+      "abbrev": "Ont",
+      "ABBREV": "ON"
     },
     {
       "path": "ca/pe",
       "name": "Prince Edward Island",
-      "abbrev": "PEI",
-      "ABBREV": "PE",
       "courts" : [
         "supreme.court.appeal.division",
         "supreme.court.trial.division.pe"
-      ]
+      ],
+      "abbrev": "PEI",
+      "ABBREV": "PE"
     },
     {
       "path": "ca/qc",
       "name": "Québec",
-      "abbrev": "Qc",
-      "ABBREV": "QC",
       "courts" : [
         "court.appeal",
         "superior.court",
         "court.quebec",
-        "tribunal.professions"
-      ]
+        "tribunal.professions",
+        "quebec.admin.tribunal"
+      ],
+      "abbrev": "Qc",
+      "ABBREV": "QC"
     },
     {
       "path": "ca/sk",
       "name": "Saskatchewan",
-      "abbrev": "Sask",
-      "ABBREV": "SK",
       "courts" : [
         "court.appeal",
         "court.queens.bench",
         "provincial.court"
-      ]
+      ],
+      "abbrev": "Sask",
+      "ABBREV": "SK"
     },
     {
       "path": "ca/yk",
       "name": "Yukon",
-      "abbrev": "Y",
-      "ABBREV": "YK",
       "courts" : [
         "court.appeal",
         "supreme.court.prov",
         "territorial.court",
         "small.claims.court"
-      ]
+      ],
+      "abbrev": "Y",
+      "ABBREV": "YK"
     }
 
   ]

--- a/src/juris-ca-desc.json
+++ b/src/juris-ca-desc.json
@@ -1,182 +1,269 @@
 {
   "courts": {
-    "court.appeal": {
-      "name": "Court of Appeal"
-    },
-    "court.queen.bench": {
-      "name": "Court of Queen's Bench"
-    },
-    "provincial.court": {
-      "name": "Provincial Court"
-    },
     "supreme.court": {
-      "name": "Supreme Court"
-    },
-    "court.queens.bench": {
-      "name": "Supreme Court"
-    },
-    "territorial.court": {
-      "name": "Territorial Court"
-    },
-    "court.justice": {
-      "name": "Court of Justice"
-    },
-    "superior.court.justice": {
-      "name": "Superior Court of Justice"
-    },
-    "court.appeal.division.supreme.court": {
-      "name": "Court of Appeal Division of Supreme Court"
-    },
-    "superior.court": {
-      "name": "Superior Court"
-    },
-    "competition.tribunal": {
-      "name": "Competition Tribunal"
-    },
-    "court.martial.appeal.court": {
-      "name": "Court Martial Appeal Court"
+      "name": "Supreme Court of Canada",
+      "abbrev": "SC>",
+      "abbrev:fr": "CS>"
     },
     "federal.court": {
-      "name": "Federal Court"
+      "name": "Federal Court",
+      "abbrev": "FC",
+      "abbrev:fr": "CF"
     },
     "federal.court.appeal": {
-      "name": "Federal Court of Appeal"
-    },
-    "human.rights.tribunal": {
-      "name": "Human Rights Tribunal"
+      "name": "Federal Court of Appeal",
+      "abbrev": "FCA",
+      "abbrev:fr": "CAF"
     },
     "tax.court": {
-      "name": "Tax Court"
+      "name": "Tax Court of Canada",
+      "abbrev": "TC>",
+      "abbrev:fr": "CCI"
+    },
+    "court.martial.appeal.court": {
+      "name": "Court Martial Appeal Court of Canada",
+      "abbrev": "CMA>",
+      "abbrev:fr": "CAM>"
+    },
+    "court.appeal": {
+      "name": "Court of Appeal",
+      "abbrev": "<CA",
+      "ABBREV": "<CA"
+    },
+    "court.queens.bench": {
+      "name": "Court of Queen's Bench",
+      "abbrev": "<QB",
+      "ABBREV": "<QB"
+    },
+    "provincial.court": {
+      "name": "Provincial Court",
+      "abbrev": "<PC",
+      "ABBREV": "<PC"
+    },
+    "supreme.court.prov": {
+      "name": "Supreme Court",
+      "abbrev": "<SC",
+      "ABBREV": "<SC"
+    },
+    "supreme.court.court.appeal": {
+      "name": "Supreme Court, Court of Appeal",
+      "abbrev": "<CA",
+      "ABBREV": "<CA"
+    },
+    "supreme.court.trial.division.nl": {
+      "name": "Supreme Court Trial Division",
+      "abbrev": "<TD",
+      "ABBREV": "<TD"
+    },
+    "territorial.court": {
+      "name": "Territorial Court",
+      "abbrev": "<TC",
+      "ABBREV": "<TC"
+    },
+    "family.court": {
+      "name": "Family Court",
+      "abbrev": "<FC",
+      "ABBREV": "<FC"
+    },
+    "court.justice": {
+      "name": "Court of Justice",
+      "abbrev": "<CJ",
+      "ABBREV": "<CJ"
+    },
+    "superior.court.justice": {
+      "name": "Superior Court of Justice",
+      "abbrev": "<SC",
+      "ABBREV": "<SC"
+    },
+    "supreme.court.appeal.division": {
+      "name": "Supreme Court, Appeal Divison",
+      "abbrev": "<CA",
+      "ABBREV": "<CA"
+    },
+    "supreme.court.trial.division.pe": {
+      "name": "Supreme Court, Trial Divison",
+      "abbrev": "<SC",
+      "ABBREV": "<SC"
+    },
+    "court.quebec": {
+      "name": "Court of Québec",
+      "abbrev": "<CQ",
+      "ABBREV": "<CQ"
+    },
+    "tribunal.professions": {
+      "name": "Tribunal des professions",
+      "abbrev": "<TP",
+      "ABBREV": "<TP"
+    },
+    "small.claims.court": {
+      "name": "Small Claims Court",
+      "abbrev": "<SM",
+      "ABBREV": "<SM"
+    },
+    "superior.court": {
+      "name": "Superior Court",
+      "abbrev": "<CS",
+      "ABBREV": "<CS"
     }
   },
   "jurisdictions": [
     {
       "path": "ca",
       "name": "Canada",
+      "abbrev": "C",
       "courts": [
-        "competition.tribunal",
-        "court.martial.appeal.court",
+        "supreme.court",
         "federal.court",
         "federal.court.appeal",
-        "human.rights.tribunal",
-        "supreme.court",
-        "tax.court"
+        "tax.court",
+        "court.martial.appeal.court"
       ]
     },
     {
       "path": "ca/ab",
       "name": "Alberta",
-      "courts": [
+      "abbrev": "Alta",
+      "ABBREV": "AB",
+      "courts" : [
         "court.appeal",
-        "court.queen.bench",
+        "court.queens.bench",
         "provincial.court"
       ]
     },
     {
       "path": "ca/bc",
       "name": "British Columbia",
+      "abbrev": "BC",
+      "ABBREV": "BC",
       "courts": [
         "court.appeal",
-        "provincial.court",
-        "supreme.court"
+        "supreme.court.prov",
+        "provincial.court"
       ]
     },
     {
       "path": "ca/mb",
       "name": "Manitoba",
-      "courts": [
-        "court.appeal",
-        "court.queen.bench",
-        "provincial.court"
-      ]
-    },
-    {
-      "path": "ca/nb",
-      "name": "New Brunswick",
-      "courts": [
+      "abbrev": "Man",
+      "ABBREV": "MB",
+      "courts" : [
         "court.appeal",
         "court.queens.bench",
         "provincial.court"
       ]
     },
     {
+      "path": "ca/NB",
+      "name": "New-Brunswick",
+      "abbrev": "NB",
+      "abbrev:fr": "N-B",
+      "ABBREV": "NB",
+      "courts" : [
+        "court.appeal",
+        "court.queens.bench",
+        "provincial.court"        
+      ]
+    },
+    {
       "path": "ca/nl",
-      "name": "Newfoundland and Labrador",
-      "courts": [
-        "court.appeal",
-        "provincial.court",
-        "supreme.court"
+      "name": "Newfoundland & Labrador",
+      "abbrev": "NL",
+      "ABBREV": "NL",
+      "courts" : [
+        "supreme.court.court.appeal",
+        "supreme.court.trial.division.nl"        
       ]
     },
     {
-      "path": "ca/ns",
-      "name": "Nova Scotia",
-      "courts": [
-        "court.appeal",
-        "provincial.court",
-        "supreme.court"
-      ]
-    },
-    {
-      "path": "ca/nt",
+      "path": "ca/nwt",
       "name": "Northwest Territories",
-      "courts": [
+      "abbrev": "NWT",
+      "abbrev:fr": "TN-O",
+      "ABBREV": "NWT",
+      "courts" : [
         "court.appeal",
-        "supreme.court",
+        "supreme.court.prov",
         "territorial.court"
+      ]
+    },
+    {
+      "path": "ca/NS",
+      "name": "Nova Scotia",
+      "abbrev": "NS",
+      "ABBREV": "NS",
+      "courts" : [
+        "court.appeal",
+        "supreme.court.prov",
+        "family.court",
+        "provincial.court"
       ]
     },
     {
       "path": "ca/nu",
       "name": "Nunavut",
-      "courts": [
-        "court.justice"
+      "abbrev": "Nu",
+      "ABBREV": "NU",
+      "courts" : [
+        "court.justice",
+        "court.appeal"
       ]
     },
     {
       "path": "ca/on",
       "name": "Ontario",
-      "courts": [
+      "abbrev": "Ont",
+      "ABBREV": "ON",
+      "courts" : [
         "court.appeal",
-        "provincial.court",
-        "superior.court.justice"
+        "superior.court.justice",
+        "court.justice"
       ]
     },
     {
       "path": "ca/pe",
       "name": "Prince Edward Island",
-      "courts": [
-        "court.appeal.division.supreme.court",
-        "provincial.court",
-        "supreme.court"
+      "abbrev": "PEI",
+      "ABBREV": "PE",
+      "courts" : [
+        "supreme.court.appeal.division",
+        "supreme.court.trial.division.pe"
       ]
     },
     {
       "path": "ca/qc",
-      "name": "Quebec",
-      "courts": [
+      "name": "Québec",
+      "abbrev": "Qc",
+      "ABBREV": "QC",
+      "courts" : [
         "court.appeal",
-        "provincial.court",
-        "superior.court"
+        "superior.court",
+        "court.quebec",
+        "tribunal.professions"
       ]
     },
     {
       "path": "ca/sk",
       "name": "Saskatchewan",
-      "courts": [
+      "abbrev": "Sask",
+      "ABBREV": "SK",
+      "courts" : [
         "court.appeal",
         "court.queens.bench",
         "provincial.court"
       ]
     },
     {
-      "path": "ca/yt",
+      "path": "ca/yk",
       "name": "Yukon",
-      "courts": [
+      "abbrev": "Y",
+      "ABBREV": "YK",
+      "courts" : [
         "court.appeal",
-        "supreme.court",
-        "territorial.court"
+        "supreme.court.prov",
+        "territorial.court",
+        "small.claims.court"
       ]
     }
+
   ]
 }

--- a/src/juris-ca-desc.json
+++ b/src/juris-ca-desc.json
@@ -153,7 +153,7 @@
       ]
     },
     {
-      "path": "ca/NB",
+      "path": "ca/nb",
       "name": "New-Brunswick",
       "abbrev": "NB",
       "abbrev:fr": "N-B",
@@ -175,19 +175,7 @@
       ]
     },
     {
-      "path": "ca/nwt",
-      "name": "Northwest Territories",
-      "abbrev": "NWT",
-      "abbrev:fr": "TN-O",
-      "ABBREV": "NWT",
-      "courts" : [
-        "court.appeal",
-        "supreme.court.prov",
-        "territorial.court"
-      ]
-    },
-    {
-      "path": "ca/NS",
+      "path": "ca/ns",
       "name": "Nova Scotia",
       "abbrev": "NS",
       "ABBREV": "NS",
@@ -196,6 +184,18 @@
         "supreme.court.prov",
         "family.court",
         "provincial.court"
+      ]
+    },
+    {
+      "path": "ca/nt",
+      "name": "Northwest Territories",
+      "abbrev": "NWT",
+      "abbrev:fr": "TN-O",
+      "ABBREV": "NWT",
+      "courts" : [
+        "court.appeal",
+        "supreme.court.prov",
+        "territorial.court"
       ]
     },
     {


### PR DESCRIPTION
I added a lot of courts, abbrev and ABBREV, as well as a ca-fr variant for french abbreviations.

I'm still struggling with the federal level ABBREVs. The federal courts (Supreme, Federal, Federal Appeal, Tax and Martial) have different neutral citation identifiers based on whether the french or english version of the jugement is being cited. I couldn't figure out how to account for this.