### PR TITLE
Correct IBFD abbrevs

### DIFF
--- a/src/juris-at-desc.json
+++ b/src/juris-at-desc.json
@@ -10,7 +10,7 @@
       "abbrev": "LVwG %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Regional Administrative Court %s"
+          "abbrev": "LVwG %s [Regional Administrative Court]"
         }
       }
     },
@@ -19,7 +19,7 @@
       "abbrev": "BG %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "District Court %s"
+          "abbrev": "BG %s [District Court]"
         }
       }
     },
@@ -28,7 +28,7 @@
       "abbrev": "LGS %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Regional Criminal Court %s"
+          "abbrev": "LGS %s [Regional Criminal Court]"
         }
       }
     },
@@ -37,7 +37,7 @@
       "abbrev": "LGZ %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Regional Civil Court %s"
+          "abbrev": "LGZ %s [Regional Civil Court]"
         }
       }
     },
@@ -46,7 +46,7 @@
       "abbrev": "LG %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Regional Court %s"
+          "abbrev": "LG %s [Regional Court]"
         }
       }
     },
@@ -55,24 +55,34 @@
       "abbrev": "OLG %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Higher Regional Court %s"
+          "abbrev": "OLG %s [Higher Regional Court]"
         }
       }
     },
     "asg": {
       "name": "Arbeits und Sozialgericht",
-      "abbrev": "ASG %s"
+      "abbrev": "ASG %s",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "ASG %s [Labour and Social Court]"
+        }
+      }
     },
     "hg": {
       "name": "Handelsgericht",
-      "abbrev": "HG %s"
+      "abbrev": "HG %s",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "HG %s [Commercial Court]"
+        }
+      }
     },
     "vgw": {
       "name": "Verwaltungsgericht",
       "abbrev": "VGW",
       "variants": {
         "enIBFD": {
-          "abbrev": "Regional Administrative Court %s"
+          "abbrev": "VGW [Regional Administrative Court]"
         }
       }
     },
@@ -81,7 +91,7 @@
       "abbrev": "BFG",
       "variants": {
         "enIBFD": {
-          "abbrev": "Federal Tax Court"
+          "abbrev": "BFG [Federal Tax Court]"
         }
       }
     },
@@ -90,7 +100,7 @@
       "abbrev": "BVwG",
       "variants": {
         "enIBFD": {
-          "abbrev": "Federal Administrative Court"
+          "abbrev": "BVwG [Federal Administrative Court]"
         }
       }
     },
@@ -99,7 +109,7 @@
       "abbrev": "OGH",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Court"
+          "abbrev": "OGH [Supreme Court]"
         }
       }
     },
@@ -108,7 +118,7 @@
       "abbrev": "VfGH",
       "variants": {
         "enIBFD": {
-          "abbrev": "Constitutional Court"
+          "abbrev": "VfGH [Constitutional Court]"
         }
       }
     },
@@ -117,7 +127,7 @@
       "abbrev": "VwGH",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Administrative Court"
+          "abbrev": "VwGH [Supreme Administrative Court]"
         }
       }
     },
@@ -130,7 +140,7 @@
       "abbrev": "UVS %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Independent Administrative Senate"
+          "abbrev": "UVS %s [Independent Administrative Senate]"
         }
       }
     },
@@ -143,7 +153,7 @@
       "abbrev": "UFS",
       "variants": {
         "enIBFD": {
-          "abbrev": "Independent Finance Senate"
+          "abbrev": "UFS [Independent Finance Senate]"
         }
       }
     },

--- a/src/juris-cy-desc.json
+++ b/src/juris-cy-desc.json
@@ -9,7 +9,7 @@
       "name": "Επαρχιακά Δικαστήρια",
       "variants": {
         "enIBFD": {
-          "abbrev": "District Court %s"
+          "abbrev": "DC %s [District Court]"
         }
       }
     },
@@ -41,7 +41,7 @@
       "name": "Ανώτατο Δικαστήριο",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Court"
+          "abbrev": "SC [Supreme Court]"
         }
       }
     }

--- a/src/juris-cz-desc.json
+++ b/src/juris-cz-desc.json
@@ -10,7 +10,7 @@
       "abbrev": "Krajský soud %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Regional Court %s"
+          "abbrev": "KS %s [Regional Court]"
         }
       }
     },
@@ -35,7 +35,7 @@
       "abbrev": "Nejvyšší soud",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Court"
+          "abbrev": "NS [Supreme Court]"
         }
       }
     },
@@ -44,7 +44,7 @@
       "abbrev": "Nejvyšší správní soud",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Administrative Court"
+          "abbrev": "NSS [Supreme Administrative Court]"
         }
       }
     },
@@ -53,7 +53,7 @@
       "abbrev": "Ústavní soud",
       "variants": {
         "enIBFD": {
-          "abbrev": "Constitutional Court"
+          "abbrev": "US [Constitutional Court]"
         }
       }
     }

--- a/src/juris-de-desc.json
+++ b/src/juris-de-desc.json
@@ -34,7 +34,7 @@
       "ABBREV": "FG %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Tax Court %s"
+          "abbrev": "FG %s [Tax Court]"
         }
       }
     },
@@ -87,7 +87,7 @@
       "ABBREV": "BFH",
       "variants": {
         "enIBFD": {
-          "abbrev": "Federal Tax Court"
+          "abbrev": "BFH [Federal Tax Court]"
         }
       }
     },

--- a/src/juris-dk-desc.json
+++ b/src/juris-dk-desc.json
@@ -9,7 +9,7 @@
       "name": "Byret %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "District Court %s"
+          "abbrev": "BR %s [District Court]"
         }
       }
     },
@@ -17,7 +17,7 @@
       "name": "Vestre Landsret",
       "variants": {
         "enIBFD": {
-          "abbrev": "High Court of Western Denmark"
+          "abbrev": "VLR [High Court of Western Denmark]"
         }
       }
     },
@@ -25,7 +25,7 @@
       "name": "Østre Landsret",
       "variants": {
         "enIBFD": {
-          "abbrev": "High Court of Eastern Denmark"
+          "abbrev": "ØLR [High Court of Eastern Denmark]"
         }
       }
     },
@@ -46,7 +46,7 @@
       "abbrev": "H",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Court"
+          "abbrev": "HR [Supreme Court]"
         }
       }
     },
@@ -60,7 +60,7 @@
       "name": "Skatterådet",
       "variants": {
         "enIBFD": {
-          "abbrev": "National Tax Board"
+          "abbrev": "SR [National Tax Board]"
         }
       }
     },
@@ -68,7 +68,7 @@
       "name": "Landsskatteretten",
       "variants": {
         "enIBFD": {
-          "abbrev": "National Tax Tribunal"
+          "abbrev": "LSR [National Tax Tribunal]"
         }
       }
     }

--- a/src/juris-es-desc.json
+++ b/src/juris-es-desc.json
@@ -16,7 +16,7 @@
       "ABBREV": "TS",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Court"
+          "abbrev": "TS [Supreme Court]"
         }
       }
     },
@@ -36,7 +36,7 @@
       "ABBREV": "TSJ %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "High Court of Justice %s"
+          "abbrev": "TSJ %s [High Court of Justice]"
         }
       }
     },
@@ -46,7 +46,7 @@
       "ABBREV": "AN",
       "variants": {
         "enIBFD": {
-          "abbrev": "National Court"
+          "abbrev": "AN [National Court]"
         }
       }
     },
@@ -56,7 +56,7 @@
       "ABBREV": "AP %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Provincial Court %s"
+          "abbrev": "AP %s [Provincial Court]"
         }
       }
     },
@@ -69,6 +69,16 @@
       "name": "Juzgado de lo Mercantil",
       "abbrev": "Juzgado de lo Mercantil de %s",
       "ABBREV": "JM %s"
+    },
+    "teac": {
+      "name": "Tribunal económico administrativo central",
+      "abbrev": "Tribunal económico administrativo central",
+      "ABBREV": "TEAC",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "TEAC [Central Economic-Administrative Court]"
+        }
+      }
     }
   },
   "jurisdictions": {
@@ -79,7 +89,8 @@
         "ts": {},
         "rmc": {},
         "dgrn": {},
-        "tc": {}
+        "tc": {},
+        "teac": {}
       }
     },
     "es:andalucia": {

--- a/src/juris-fi-desc.json
+++ b/src/juris-fi-desc.json
@@ -11,7 +11,7 @@
       "ABBREV": "HAO",
       "variants": {
         "enIBFD": {
-          "abbrev": "%s Regional Administrative Court"
+          "abbrev": "HAO %s [Regional Administrative Court]"
         }
       }
     },
@@ -50,7 +50,7 @@
       "ABBREV": "KHO",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Administrative Court"
+          "abbrev": "KHO [Supreme Administrative Court]"
         }
       }
     },

--- a/src/juris-fr-desc.json
+++ b/src/juris-fr-desc.json
@@ -10,7 +10,7 @@
       "abbrev": "Cass.",
       "variants": {
         "enIBFD": {
-          "abbrev": "Court of Cassation"
+          "abbrev": "CC [Court of Cassation]"
         }
       }
     },
@@ -53,7 +53,7 @@
       "name": "Conseil d'État",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Administrative Court"
+          "abbrev": "CE [Supreme Administrative Court]"
         }
       }
     },
@@ -86,16 +86,16 @@
       "abbrev": "C.A.A. %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Administrative Court of Appeals %s"
+          "abbrev": "CAA %s [Administrative Court of Appeals]"
         }
       }
     },
     "ta": {
       "name": "Tribunal administratif",
-      "abbrev": "TA %",
+      "abbrev": "TA %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Administrative Tribunal %s"
+          "abbrev": "TA %s [Administrative Tribunal]"
         }
       }
     }

--- a/src/juris-gr-desc.json
+++ b/src/juris-gr-desc.json
@@ -15,7 +15,7 @@
       "name": "ΔΙΟΙΚΗΤΙΚΑ ΠΡΩΤΟΔΙΚΕΙΑ",
       "variants": {
         "enIBFD": {
-          "abbrev": "Administrative Court of First Instance %s"
+          "abbrev": "DP %s [Administrative Court of First Instance]"
         }
       }
     },
@@ -23,7 +23,7 @@
       "name": "ΔΙΟΙΚΗΤΙΚΑ ΕΦΕΤΕΙΑ",
       "variants": {
         "enIBFD": {
-          "abbrev": "Administrative Court of Appeal %s"
+          "abbrev": "DE %s [Administrative Court of Appeal]"
         }
       }
     },
@@ -37,7 +37,7 @@
       "name": "Συμβούλιο της Επικρατείας",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Administrative Court"
+          "abbrev": "SE [Supreme Administrative Court]"
         }
       }
     },

--- a/src/juris-it-desc.json
+++ b/src/juris-it-desc.json
@@ -9,7 +9,7 @@
       "name": "Corte Suprema di Cassazione",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Court"
+          "abbrev": " Cass. [Supreme Court]"
         }
       }
     },
@@ -20,7 +20,7 @@
       "name": "Corte Costituzionale",
       "variants": {
         "enIBFD": {
-          "abbrev": "Constitutional Court"
+          "abbrev": "C. Cost. [Constitutional Court]"
         }
       }
     },
@@ -37,15 +37,25 @@
       "name": "Commissione Tributaria Centrale",
       "variants": {
         "enIBFD": {
-          "abbrev": "Central Tax Court"
+          "abbrev": "CTC [Central Tax Court]"
         }
       }
     },
     "ctp": {
-      "name": "Commissione Tributaria Provinciale di %s"
+      "name": "Commissione Tributaria Provinciale di %s",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "CTP %s [First Instance Tax Court]"
+        }
+      }
     },
     "ctr": {
-      "name": "Commissione Tributaria Regionale di %s"
+      "name": "Commissione Tributaria Regionale di %s",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "CTR %s [Tax Court of Appeal]"
+        }
+      }
     },
     "tar": {
       "name": "Tribunale Administrativo Regionale di %s"

--- a/src/juris-nl-desc.json
+++ b/src/juris-nl-desc.json
@@ -10,7 +10,7 @@
 			"abbrev": "HR",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Court"
+          "abbrev": "HR [Supreme Court]"
         }
       }
 		},
@@ -18,7 +18,7 @@
 			"name": "%s Gerechtshof",
       "variants": {
         "enIBFD": {
-          "abbrev": "Court of Appeal %s"
+          "abbrev": "Hof %s [Court of Appeal]"
         }
       }
 		},
@@ -26,7 +26,7 @@
 			"name": "%s Rechtbank",
       "variants": {
         "enIBFD": {
-          "abbrev": "District Court %s"
+          "abbrev": "Rb %s [District Court]"
         }
       }
 		},
@@ -38,7 +38,7 @@
 			"abbrev": "CRvB",
       "variants": {
         "enIBFD": {
-          "abbrev": "Central Board of Appeal"
+          "abbrev": "CRB [Central Board of Appeal]"
         }
       }
 		},
@@ -51,7 +51,7 @@
 			"abbrev": "RvS",
       "variants": {
         "enIBFD": {
-          "abbrev": "Council of State"
+          "abbrev": "RvS [Council of State]"
         }
       }
 		}
@@ -73,14 +73,24 @@
 			"comment": "< 2013 >",
 			"courts": {
 				"gerechtshof": {}
-			}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "A"
+        }
+      }
 		},
 		"nl:amsterdam:amsterdam": {
 			"name": "Amsterdam",
 			"comment": "< 2013 >",
 			"courts": {
 				"rechtbank": {}
-			}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "A"
+        }
+      }
 		},
 		"nl:amsterdam:haarlem": {
 			"name": "Haarlem",
@@ -108,7 +118,12 @@
 			"comment": "2013 >",
 			"courts": {
 				"rechtbank": {}
-			}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "NH"
+        }
+      }
 		},
 		"nl:arnhem": {
 			"name": "Arnhem",
@@ -178,20 +193,35 @@
 			"comment": "2013 >",
 			"courts": {
 				"gerechtshof": {}
-			}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "A-L"
+        }
+      }
 		},
 		"nl:arnhem.leeuwarden:gelderland": {
 			"name": "Gelderland",
 			"comment": "2013 >",
 			"courts": {
 				"rechtbank": {}
-			}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "GLD"
+        }
+      }
 		},
 		"nl:arnhem.leeuwarden:midden.nederland": {
 			"name": "Midden-Nederland",
 			"comment": "2013 >",
 			"courts": {
 				"rechtbank": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "MN"
+        }
 			}
 		},
 		"nl:arnhem.leeuwarden:noord.nederland": {
@@ -199,6 +229,11 @@
 			"comment": "2013 >",
 			"courts": {
 				"rechtbank": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "NN"
+        }
 			}
 		},
 		"nl:arnhem.leeuwarden:overijssel": {
@@ -206,6 +241,11 @@
 			"comment": "2013 >",
 			"courts": {
 				"rechtbank": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "OV"
+        }
 			}
 		},
 		"nl:gravenhage": {
@@ -213,6 +253,11 @@
 			"comment": "< 2013 >",
 			"courts": {
 				"gerechtshof": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "DH"
+        }
 			}
 		},
 		"nl:gravenhage:gravenhage": {
@@ -220,6 +265,11 @@
 			"comment": "< 2013 >",
 			"courts": {
 				"rechtbank": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "DH"
+        }
 			}
 		},
 		"nl:gravenhage:rotterdam": {
@@ -227,6 +277,11 @@
 			"comment": "< 2013 >",
 			"courts": {
 				"rechtbank": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "R."
+        }
 			}
 		},
 		"nl:gravenhage:dordrecht": {
@@ -241,6 +296,11 @@
 			"comment": "< 2013 >",
 			"courts": {
 				"gerechtshof": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "DB"
+        }
 			}
 		},
 		"nl:hertogenbosch:hertogenbosch": {
@@ -276,6 +336,11 @@
 			"comment": "2013 >",
 			"courts": {
 				"rechtbank": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "L"
+        }
 			}
 		},
 		"nl:hertogenbosch:oost.brabant": {
@@ -283,6 +348,11 @@
 			"comment": "2013 >",
 			"courts": {
 				"rechtbank": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "OB"
+        }
 			}
 		},
 		"nl:hertogenbosch:zeeland-west-brabant": {
@@ -290,6 +360,11 @@
 			"comment": "2013 >",
 			"courts": {
 				"rechtbank": {}
+			},
+			"variants": {
+        "enIBFD": {
+          "abbrev": "ZWB"
+        }
 			}
 		}
 	}

--- a/src/juris-nz-desc.json
+++ b/src/juris-nz-desc.json
@@ -1,8 +1,17 @@
 {
-  "langs": {},
+  "langs": {
+    "enIBFD": [
+      "abbrevs"
+    ]
+  },
   "courts": {
     "high.court": {
-      "name": "High Court"
+      "name": "High Court",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "NZHC %s"
+        }
+      }
     },
     "land.court": {
       "name": "Land Court"
@@ -17,7 +26,12 @@
       "name": "Broadcasting Standards Authority"
     },
     "ca": {
-      "name": "Court Appeal"
+      "name": "Court Appeal",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "NZCA"
+        }
+      }
     },
     "caa": {
       "name": "Customs Appeal Authority"
@@ -68,7 +82,12 @@
       "name": "Student Allowance Appeal Authority"
     },
     "sc": {
-      "name": "Supreme Court"
+      "name": "Supreme Court",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "NZSC"
+        }
+      }
     },
     "shd": {
       "name": "Licensing Authority Of Secondhand Dealers And Pawnbrokers"
@@ -77,7 +96,12 @@
       "name": "Social Security Appeal Authority"
     },
     "tra": {
-      "name": "Taxation Review Authority"
+      "name": "Taxation Review Authority",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "NZTRA"
+        }
+      }
     }
   },
   "jurisdictions": {

--- a/src/juris-pl-desc.json
+++ b/src/juris-pl-desc.json
@@ -18,7 +18,7 @@
       "name": "Woj. Sąd Administracyjny %s",
       "variants": {
         "enIBFD": {
-          "abbrev": "Regional Administrative Court %s"
+          "abbrev": "WSA %s [Regional Administrative Court]"
         }
       }
     },
@@ -26,7 +26,7 @@
       "name": "Najwyższy Sąd Administracyjny",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Administrative Court"
+          "abbrev": "NSA [Supreme Administrative Court]"
         }
       }
     },

--- a/src/juris-pt-desc.json
+++ b/src/juris-pt-desc.json
@@ -30,7 +30,7 @@
       "ABBREV": "STA",
       "variants": {
         "enIBFD": {
-          "abbrev": "Supreme Administrative Court"
+          "abbrev": "STA [Supreme Administrative Court]"
         }
       }
     },
@@ -39,7 +39,7 @@
       "ABBREV": "TCAN",
       "variants": {
         "enIBFD": {
-          "abbrev": "Central Administrative Courts – North"
+          "abbrev": "TCA %s [Central Administrative Courts – North]"
         }
       }
     },
@@ -48,7 +48,7 @@
       "ABBREV": "TCAS",
       "variants": {
         "enIBFD": {
-          "abbrev": "Central Administrative Courts – South"
+          "abbrev": "TCA %s [Central Administrative Courts – South]"
         }
       }
     },
@@ -62,7 +62,7 @@
       "name": "Administrativo e Fiscal",
       "variants": {
         "enIBFD": {
-          "abbrev": "Administrative Court of First Instance %s"
+          "abbrev": "TAF %s [Administrative Court of First Instance]"
         }
       }
     },
@@ -73,7 +73,7 @@
       "name": "Administrativo e Fiscal",
       "variants": {
         "enIBFD": {
-          "abbrev": "Administrative Court of First Instance %s"
+          "abbrev": "TAF %s [Administrative Court of First Instance]"
         }
       }
     },

--- a/src/juris-se-desc.json
+++ b/src/juris-se-desc.json
@@ -15,13 +15,26 @@
       "name": "Tingsrätt"
     },
     "regeringsratten": {
-      "name": "Regeringsrätten"
+      "name": "Regeringsrätten",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "RÅ [Supreme Administrative Court]"
+        }
+      }
+    },
+    "hogsta.forvaltningsdomstolen": {
+      "name": "Högsta förvaltningsdomstolen",
+      "variants": {
+        "enIBFD": {
+          "abbrev": "HFD [Supreme Administrative Court]"
+        }
+      }
     },
     "kammarratten": {
       "name": "Kammarrätten",
       "variants": {
         "enIBFD": {
-          "abbrev": "Administrative Court of Appeal %s"
+          "abbrev": "KR %s [Administrative Court of Appeal]"
         }
       }
     },
@@ -29,7 +42,7 @@
       "name": "Förvaltningsrätten",
       "variants": {
         "enIBFD": {
-          "abbrev": "Administrative Court %s"
+          "abbrev": "FR %s [Administrative Court]"
         }
       }
     },
@@ -64,6 +77,7 @@
       "courts": {
         "hogsta": {},
         "regeringsratten": {},
+        "hogsta.forvaltningsdomstolen": {},
         "arbetsdomstolen": {},
         "patent.marknadsdomstolen": {},
         "fosvarsunderrattelsedomstolen": {}


### PR DESCRIPTION
Confirmed style: `Court abbrev [Engl. Translation]`
Also:
- Adds court TEAC to ES
- Adds court Högsta förvaltningsdomstolen to SE
- Corrects default TA abbrev for FR