### PR TITLE
implement court overrides for sub-jurisdictions

### DIFF
--- a/scripts/lib/descriptiveToCompact.js
+++ b/scripts/lib/descriptiveToCompact.js
@@ -98,7 +98,7 @@ const processJurisAbbrevs = (opts, jurisID, jurisDesc) => {
 		// jurisdictions
 		for (var jKey in jurisDesc.jurisdictions) {
 			var jObj = jurisDesc.jurisdictions[jKey];
-			data.jurisdictions[jKey] = setAbbrevData(jObj, lang, ["container-title"]);
+			data.jurisdictions[jKey] = setAbbrevData(jObj, lang, ["container-title", "overrides"]);
 		}
 		// for jurisdictionCourts
 		for (var jKey in jurisDesc.jurisdictions) {
@@ -108,6 +108,13 @@ const processJurisAbbrevs = (opts, jurisID, jurisDesc) => {
 				for (var cKey in jurisdiction.courts) {
 					var cObj = jurisdiction.courts[cKey];
 					data.jurisdictions[jKey].courts[cKey] = setAbbrevData(cObj, lang, ["abbrev_select"]);
+				}
+			}
+			data.jurisdictions[jKey].overrides = {};
+			if (jurisdiction.overrides) {
+				for (var oKey in jurisdiction.overrides) {
+					var oObj = jurisdiction.overrides[oKey];
+					data.jurisdictions[jKey].overrides[oKey] = setAbbrevData(oObj, lang, ["abbrev_select"]);
 				}
 			}
 		}
@@ -128,6 +135,22 @@ const processJurisAbbrevs = (opts, jurisID, jurisDesc) => {
 					}
 					cabbrev = data.courts[cKey].abbrev;
 					cABBREV = data.courts[cKey].ABBREV;
+
+					var jParts = jKey.split(":");
+					var jPartString = jParts.shift();
+					while (jParts.length > 0) {
+						var oObj = data.jurisdictions[jPartString].overrides[cKey];
+						if ("undefined" !== typeof oObj) {
+							if (oObj.abbrev) {
+								cabbrev = oObj.abbrev;
+							}
+							if (oObj.ABBREV) {
+								cABBREV = oObj.ABBREV;
+							}
+						}
+						jPartString += ":" + jParts.shift();
+					}
+
 					var cObj = jObj.courts[cKey];
 					if ("undefined" === typeof cObj) {
 						throw new Error(`Undefined cObj from cKey=${cKey} in processJurisAbbrevs`);


### PR DESCRIPTION
Countries may define courts on different jurisdiction levels, e.g. courts of first and second instance must exist by federal mandate, but naming is delegated to direct sub-jurisdictions and the actual courts exist on a sub-sub-jurisdiction. The current implementation allows court information only to be defined globally or by jurisdiction - but knows no inheritance.

I propose to implement an inheritance of court information down the sub-jurisdiction path. This allows to easily implement the following scenario

- jurisdiction level 0 (federal) mandates courts of two instances in the lower jurisdictions
- jurisdiction level 1 (state) defines the naming of those courts
- jurisdiction level 2 (district) has the actual courts

That's how it's implemented (more or less) in Switzerland. The federal government mandates to instances but leaves everything else to the cantons/states. The cantons define the naming of the courts, also for the district level. The districts have the courts of first instance. Now, while all districts have a court of first instance, in one canton they are called 'Kreisgericht', in another 'Bezirksgericht'. I can not define this name globally and I don't want to override it for *every* district.

To keep everything compatible, I suggest adapting a new keyword `overrides` in jurisdictions that contains the 'overridden' court definitions for that jurisdictions and all sub-jurisdictions.